### PR TITLE
Remove margin-bottom on body for .ctl-register

### DIFF
--- a/themes/Frontend/Responsive/frontend/_public/src/less/_modules/register.less
+++ b/themes/Frontend/Responsive/frontend/_public/src/less/_modules/register.less
@@ -374,11 +374,6 @@ The user can see the registration steps, advantages and required information.
 
 @media screen and (min-width: @desktopViewportWidth) {
 
-    // Header Support Info
-    .is--ctl-register {
-        .unitize(margin-bottom, 48);
-    }
-
     // Register Steps
     .steps--content {
 


### PR DESCRIPTION
Removed margin-bottom of 48px on body, which was only applied in the register-controller on desktop.
Removed it, because I found no use of it.